### PR TITLE
Add rust docker image

### DIFF
--- a/rust-wasm/Dockerfile
+++ b/rust-wasm/Dockerfile
@@ -37,3 +37,7 @@ RUN chmod +x /usr/bin/codecov
 
 ADD rust-codecov /usr/bin/rust-codecov
 RUN chmod +x /usr/bin/rust-codecov
+
+# Install tarpaulin
+RUN apt-get -y install libssl-dev pkg-config cmake zlib1g-dev
+RUN RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin

--- a/rust-wasm/Dockerfile
+++ b/rust-wasm/Dockerfile
@@ -1,0 +1,14 @@
+# Author: Alex Beregszaszi
+
+FROM rust:1
+
+RUN rustup update
+
+RUN rustup install beta
+RUN rustup default stable
+
+RUN rustup target add wasm32-unknown-unknown
+RUN rustup component add rustfmt-preview
+
+RUN cargo install wasm-gc
+RUN cargo install just

--- a/rust-wasm/Dockerfile
+++ b/rust-wasm/Dockerfile
@@ -4,7 +4,7 @@
 FROM rust:1 as builder
 
 # Install dependencies
-RUN apt update -y && apt-get -y install binutils-dev wget cmake libelf-dev libdwarf-dev libdw-dev libiberty-dev
+RUN apt-get update -y && apt-get -y install binutils-dev wget cmake libelf-dev libdwarf-dev libdw-dev libiberty-dev
 
 # Build kcov
 RUN wget -O - https://github.com/SimonKagstrom/kcov/archive/v35.tar.gz | tar zxvf -
@@ -15,7 +15,7 @@ RUN make -j $(nproc) && make install
 # Create our derived image off the official rust one.
 FROM rust:1
 
-RUN apt update -y
+RUN apt-get update -y
 
 RUN rustup update
 

--- a/rust-wasm/Dockerfile
+++ b/rust-wasm/Dockerfile
@@ -1,5 +1,18 @@
 # Author: Alex Beregszaszi
 
+# Building kcov first.
+FROM rust:1 as builder
+
+# Install dependencies
+RUN apt-get install binutils-dev wget
+
+# Build kcov
+RUN wget -O - https://github.com/SimonKagstrom/kcov/archive/v35.tar.gz | tar zxvf -
+WORKDIR /build
+RUN cmake /kcov-35 -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release
+RUN make -j $(nproc) && make install
+
+# Create our derived image off the official rust one.
 FROM rust:1
 
 RUN rustup update
@@ -12,3 +25,5 @@ RUN rustup component add rustfmt-preview
 
 RUN cargo install wasm-gc
 RUN cargo install just
+
+COPY --from=builder /usr/bin/kcov /usr/bin

--- a/rust-wasm/Dockerfile
+++ b/rust-wasm/Dockerfile
@@ -30,3 +30,10 @@ RUN cargo install just
 
 RUN apt-get -y install libdw1
 COPY --from=builder /usr/bin/kcov /usr/bin
+
+# Install codecov support
+RUN wget -O - -q "https://codecov.io/bash" > /usr/bin/codecov
+RUN chmod +x /usr/bin/codecov
+
+ADD rust-codecov /usr/bin/rust-codecov
+RUN chmod +x /usr/bin/rust-codecov

--- a/rust-wasm/Dockerfile
+++ b/rust-wasm/Dockerfile
@@ -4,7 +4,7 @@
 FROM rust:1 as builder
 
 # Install dependencies
-RUN apt-get install binutils-dev wget
+RUN apt update -y && apt-get -y install binutils-dev wget cmake libelf-dev libdwarf-dev libdw-dev libiberty-dev
 
 # Build kcov
 RUN wget -O - https://github.com/SimonKagstrom/kcov/archive/v35.tar.gz | tar zxvf -
@@ -14,6 +14,8 @@ RUN make -j $(nproc) && make install
 
 # Create our derived image off the official rust one.
 FROM rust:1
+
+RUN apt update -y
 
 RUN rustup update
 
@@ -26,4 +28,5 @@ RUN rustup component add rustfmt-preview
 RUN cargo install wasm-gc
 RUN cargo install just
 
+RUN apt-get -y install libdw1
 COPY --from=builder /usr/bin/kcov /usr/bin

--- a/rust-wasm/README.md
+++ b/rust-wasm/README.md
@@ -1,0 +1,7 @@
+# ewasm/rust
+
+Builds off the [official rust docker](https://hub.docker.com/_/rust/).
+
+Adds `rustfmt`, wasm32 support, `wasm-gc` and `just`.
+
+Available as [ewasm/rust-wasm](https://hub.docker.com/ewasm/rust-wasm/).

--- a/rust-wasm/README.md
+++ b/rust-wasm/README.md
@@ -2,6 +2,8 @@
 
 Builds off the [official rust docker](https://hub.docker.com/_/rust/).
 
-Adds `rustfmt`, wasm32 support, `wasm-gc`, `just`, and `kcov`.
+Adds `rustfmt`, wasm32 support, `wasm-gc`, `just`, `kcov` and codecov.io.
 
 Available as [ewasm/rust-wasm](https://hub.docker.com/ewasm/rust-wasm/).
+
+Need to run with `--security-opt seccomp=unconfined` option to enable `kcov` support.

--- a/rust-wasm/README.md
+++ b/rust-wasm/README.md
@@ -2,8 +2,8 @@
 
 Builds off the [official rust docker](https://hub.docker.com/_/rust/).
 
-Adds `rustfmt`, wasm32 support, `wasm-gc`, `just`, `kcov` and codecov.io.
+Adds `rustfmt`, wasm32 support, `wasm-gc`, `just`, `kcov`, `tarpaulin` and codecov.io.
 
 Available as [ewasm/rust-wasm](https://hub.docker.com/ewasm/rust-wasm/).
 
-Need to run with `--security-opt seccomp=unconfined` option to enable `kcov` support.
+Need to run with `--security-opt seccomp=unconfined` option to enable `kcov` or `tarpaulin` support.

--- a/rust-wasm/README.md
+++ b/rust-wasm/README.md
@@ -2,6 +2,6 @@
 
 Builds off the [official rust docker](https://hub.docker.com/_/rust/).
 
-Adds `rustfmt`, wasm32 support, `wasm-gc` and `just`.
+Adds `rustfmt`, wasm32 support, `wasm-gc`, `just`, and `kcov`.
 
 Available as [ewasm/rust-wasm](https://hub.docker.com/ewasm/rust-wasm/).

--- a/rust-wasm/rust-codecov
+++ b/rust-wasm/rust-codecov
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e
+
+PROJECT="$1"
+
+if [[ -z "$PROJECT" ]]; then
+    echo "Project name must be given as an argument."
+    exit 1
+fi
+
+FILENAME="$PROJECT-*"
+REPORT="$(find target/debug -maxdepth 1 -name $FILENAME -a ! -name '*.d')"
+
+if [[ -z "$REPORT" ]]; then
+    echo "No report found. Was the project built yet?"
+    exit 1
+fi
+
+for file in $REPORT; do
+    mkdir -p "target/cov/$(basename $file)"
+    kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"
+done
+
+codecov -Z -t $CODECOV_TOKEN
+echo "Uploaded kcov coverage to codecov.io"


### PR DESCRIPTION
Comes with rustfmt, wasm-gc and wasm32.

Closes #2.